### PR TITLE
Remove ./ prefix to source files

### DIFF
--- a/Main.fsproj
+++ b/Main.fsproj
@@ -22,9 +22,9 @@
    !  File order is important in F#. Files cannot depend on anything below them.
    !-->
   <ItemGroup>
-    <Compile Include="./src/fs/Message.fs" />
-    <Compile Include="./src/fs/Message2.fs" />
-    <Compile Include="./src/fs/Main.fs" />
+    <Compile Include="src/fs/Message.fs" />
+    <Compile Include="src/fs/Message2.fs" />
+    <Compile Include="src/fs/Main.fs" />
   </ItemGroup>
 
   <!-- DO NOT EDIT BELOW THIS POINT UNLESS YOU KNOW WHAT YOU'RE DOING -->


### PR DESCRIPTION
If we prefix the source files with ./ then VS is showing this `.` as a folder:

![pauan_1](https://cloud.githubusercontent.com/assets/4760796/19966188/069ef498-a1cb-11e6-8925-1141a38061f4.PNG)

When removing `./` prefix:

![pauan_2](https://cloud.githubusercontent.com/assets/4760796/19966198/0f8d0f90-a1cb-11e6-87b0-8d24bad3fefe.PNG)

I tested to build running: `npm run build` and it's still build.

PS: I didn't remove `./` prefix from reference because it's marked as needed in the comments and this doesn't pollute the view in the IDE :)